### PR TITLE
Changes repo URL for ImageContrastAdjustment

### DIFF
--- a/I/ImageContrastAdjustment/Package.toml
+++ b/I/ImageContrastAdjustment/Package.toml
@@ -1,3 +1,4 @@
 name = "ImageContrastAdjustment"
 uuid = "f332f351-ec65-5f6a-b3d1-319c6670881a"
-repo = "https://github.com/zygmuntszpak/ImageContrastAdjustment.jl.git"
+repo = "https://github.com/JuliaImages/ImageContrastAdjustment.jl.git"
+


### PR DESCRIPTION
I transferred my repository so its hosted over at the `JuliaImages` organsation (https://github.com/JuliaImages/Images.jl/pull/855). This pull-request amends the repo URL so that it points to the new location.